### PR TITLE
Corrected slug

### DIFF
--- a/_data/albums.yml
+++ b/_data/albums.yml
@@ -1606,7 +1606,7 @@
   artist: Geese
   year: 2025
   genre: Rock
-  slug: geese-gettingkilled
+  slug: geese-killed
   cover: https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/0b/b8/f1/0bb8f1d7-1df0-20c0-9539-51d08058eeb1/5400863191436_Cover.jpg/600x600bb.jpg
   link: https://en.wikipedia.org/wiki/Getting_Killed
   discogs: 35210866


### PR DESCRIPTION
This pull request makes a minor update to the album data by correcting the `slug` value for a Geese album.

- Changed the `slug` for the Geese album from `geese-gettingkilled` to `geese-killed` in `_data/albums.yml`